### PR TITLE
Set the processor frequency to 456 MHz.

### DIFF
--- a/arch/arm/mach-davinci/Kconfig
+++ b/arch/arm/mach-davinci/Kconfig
@@ -66,9 +66,15 @@ config SYS_DV_CLKMODE
 	help
 	  Set PLLCTL Clock Mode bit as External Clock or On Chip oscillator
 
+config SYS_DA850_PLL0_PREDIV
+	int "PLLC0 PLL Pre-Divider"
+	default 0
+	help
+	  Value written to PLLC0 PLL Pre-Divider Control Register
+
 config SYS_DA850_PLL0_POSTDIV
 	int "PLLC0 PLL Post-Divider"
-	default 1
+	default 0
 	help
 	  Value written to PLLC0 PLL Post-Divider Control Register
 

--- a/include/configs/trikboard.h
+++ b/include/configs/trikboard.h
@@ -51,7 +51,7 @@
  * PLL configuration
  */
 
-#define CONFIG_SYS_DA850_PLL0_PLLM     24
+#define CONFIG_SYS_DA850_PLL0_PLLM     18
 #define CONFIG_SYS_DA850_PLL1_PLLM     21
 
 /*


### PR DESCRIPTION
By changing the values of the prediv, postdiv, and multiplier, we can change the frequency.

In the Linux kernel `da850.c` file, you can view the divisor and multiplier values for the supported frequencies (do not forget to subtract 1 from those values).

Before this commit, the frequency was 300 MHz.

It was not possible to launch the cpufreq module to change the frequencies in runtime, perhaps the 4.14 kernel is still raw for this, or you need to add the code yourself.